### PR TITLE
feat: login 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,17 +28,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'mysql:mysql-connector-java:8.0.33' // mysql8
     implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
-
-    implementation 'org.json:json:20200518'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
+    implementation platform("org.springframework.cloud:spring-cloud-dependencies:2022.0.3")
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
-    implementation 'org.hibernate.validator:hibernate-validator:7.0.1.Final'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,11 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	runtimeOnly 'mysql:mysql-connector-java:8.0.28' // mysql8
-
+	runtimeOnly 'mysql:mysql-connector-java:8.0.33' // mysql8
+    implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
     implementation 'org.json:json:20200518'
 

--- a/src/main/java/bangwool/server/config/AuthConfig.java
+++ b/src/main/java/bangwool/server/config/AuthConfig.java
@@ -1,0 +1,34 @@
+package bangwool.server.config;
+
+import bangwool.server.security.auth.AuthenticationPrincipalArgumentResolver;
+import bangwool.server.security.auth.LoginInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthConfig implements WebMvcConfigurer {
+
+    private final LoginInterceptor loginInterceptor;
+    private final AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loginInterceptor)
+                .addPathPatterns("/members/**", "/cafes/**")
+                .excludePathPatterns("/members", "/members/oauth", "/members/all",
+                        "/members/check-duplicate/**", "/members/email-verification", "/members/info/reset-password")
+                .excludePathPatterns("/cafes");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationPrincipalArgumentResolver);
+        WebMvcConfigurer.super.addArgumentResolvers(resolvers);
+    }
+}

--- a/src/main/java/bangwool/server/config/SecurityConfig.java
+++ b/src/main/java/bangwool/server/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package bangwool.server.config;
+
+import bangwool.server.security.EncryptUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new PasswordEncoder() {
+            @Override
+            public String encode(CharSequence rawPassword) {
+                return EncryptUtils.encrypt(rawPassword.toString());
+            }
+
+            @Override
+            public boolean matches(CharSequence rawPassword, String encodedPassword) {
+                return encodedPassword.equals(EncryptUtils.encrypt(rawPassword.toString()));
+            }
+        };
+    }
+}

--- a/src/main/java/bangwool/server/config/WebConfig.java
+++ b/src/main/java/bangwool/server/config/WebConfig.java
@@ -1,0 +1,23 @@
+package bangwool.server.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
+                .exposedHeaders(HttpHeaders.LOCATION)
+                .maxAge(5000);
+    }
+}

--- a/src/main/java/bangwool/server/controller/AuthController.java
+++ b/src/main/java/bangwool/server/controller/AuthController.java
@@ -3,6 +3,8 @@ package bangwool.server.controller;
 import bangwool.server.dto.request.AuthLoginRequest;
 import bangwool.server.dto.response.TokenResponse;
 import bangwool.server.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,12 +13,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Login", description = "인증")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/login")
 public class AuthController {
     private final AuthService authService;
 
+    @Operation(summary = "자체 로그인")
     @PostMapping
     public ResponseEntity<TokenResponse> login(@RequestBody @Valid AuthLoginRequest request) {
         TokenResponse response = authService.login(request);

--- a/src/main/java/bangwool/server/controller/AuthController.java
+++ b/src/main/java/bangwool/server/controller/AuthController.java
@@ -1,0 +1,25 @@
+package bangwool.server.controller;
+
+import bangwool.server.dto.request.AuthLoginRequest;
+import bangwool.server.dto.response.TokenResponse;
+import bangwool.server.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/login")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping
+    public ResponseEntity<TokenResponse> login(@RequestBody @Valid AuthLoginRequest request) {
+        TokenResponse response = authService.login(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/bangwool/server/controller/MemberController.java
+++ b/src/main/java/bangwool/server/controller/MemberController.java
@@ -3,20 +3,26 @@ package bangwool.server.controller;
 import bangwool.server.dto.request.MemberSignUpRequest;
 import bangwool.server.dto.response.MemberSignUpResponse;
 import bangwool.server.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Members", description = "회원")
 @RestController
-@RequestMapping("/member")
+@RequiredArgsConstructor
+@RequestMapping("/members")
 @Slf4j
 public class MemberController {
-    @Autowired
-    private MemberService memberService;
 
+    private final MemberService memberService;
 
-    @PostMapping("/signup")
+    @Operation(summary = "회원가입")
+    @PostMapping
     public ResponseEntity<MemberSignUpResponse> signUp(@Valid @RequestBody MemberSignUpRequest memberSignUpRequest) {
         MemberSignUpResponse memberSignUpResponse = memberService.save(memberSignUpRequest);
 

--- a/src/main/java/bangwool/server/dto/request/AuthLoginRequest.java
+++ b/src/main/java/bangwool/server/dto/request/AuthLoginRequest.java
@@ -1,0 +1,19 @@
+package bangwool.server.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@ToString
+public class AuthLoginRequest {
+
+    @Email(message = "1006:이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String email;
+
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String password;
+}

--- a/src/main/java/bangwool/server/dto/response/TokenResponse.java
+++ b/src/main/java/bangwool/server/dto/response/TokenResponse.java
@@ -1,0 +1,18 @@
+package bangwool.server.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class TokenResponse {
+    private String token;
+
+    public static TokenResponse from(final String token) {
+        return new TokenResponse(token);
+    }
+}

--- a/src/main/java/bangwool/server/exception/badreqeust/BlankTokenException.java
+++ b/src/main/java/bangwool/server/exception/badreqeust/BlankTokenException.java
@@ -1,0 +1,8 @@
+package bangwool.server.exception.badreqeust;
+
+public class BlankTokenException extends BadRequestException {
+
+    public BlankTokenException() {
+        super("토큰은 공백일 수 없습니다.", 1018);
+    }
+}

--- a/src/main/java/bangwool/server/exception/badreqeust/PasswordMismatchException.java
+++ b/src/main/java/bangwool/server/exception/badreqeust/PasswordMismatchException.java
@@ -1,0 +1,8 @@
+package bangwool.server.exception.badreqeust;
+
+public class PasswordMismatchException extends BadRequestException {
+
+    public PasswordMismatchException() {
+        super("비밀번호가 올바르지 않습니다.", 1003);
+    }
+}

--- a/src/main/java/bangwool/server/exception/notfound/NotFoundException.java
+++ b/src/main/java/bangwool/server/exception/notfound/NotFoundException.java
@@ -1,0 +1,13 @@
+package bangwool.server.exception.notfound;
+
+import bangwool.server.exception.BangwoolException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class NotFoundException extends BangwoolException {
+
+    public NotFoundException(String message, int code) {
+        super(HttpStatus.NOT_FOUND, message, code);
+    }
+}

--- a/src/main/java/bangwool/server/exception/notfound/NotFoundMemberException.java
+++ b/src/main/java/bangwool/server/exception/notfound/NotFoundMemberException.java
@@ -1,0 +1,11 @@
+package bangwool.server.exception.notfound;
+
+import lombok.Getter;
+
+@Getter
+public class NotFoundMemberException extends NotFoundException {
+
+    public NotFoundMemberException() {
+        super("존재하지 않는 회원입니다.", 1001);
+    }
+}

--- a/src/main/java/bangwool/server/exception/unauthorized/InvalidBearerException.java
+++ b/src/main/java/bangwool/server/exception/unauthorized/InvalidBearerException.java
@@ -1,0 +1,8 @@
+package bangwool.server.exception.unauthorized;
+
+public class InvalidBearerException extends UnauthorizedException {
+
+    public InvalidBearerException() {
+        super("로그인이 필요한 서비스입니다.", 1013);
+    }
+}

--- a/src/main/java/bangwool/server/exception/unauthorized/InvalidTokenException.java
+++ b/src/main/java/bangwool/server/exception/unauthorized/InvalidTokenException.java
@@ -1,0 +1,12 @@
+package bangwool.server.exception.unauthorized;
+
+public class InvalidTokenException extends UnauthorizedException {
+
+    public InvalidTokenException() {
+        super("올바르지 않은 토큰입니다. 다시 로그인해주세요.", 1015);
+    }
+
+    public InvalidTokenException(String message) {
+        super(message, 1015);
+    }
+}

--- a/src/main/java/bangwool/server/exception/unauthorized/TokenExpiredException.java
+++ b/src/main/java/bangwool/server/exception/unauthorized/TokenExpiredException.java
@@ -1,0 +1,12 @@
+package bangwool.server.exception.unauthorized;
+
+public class TokenExpiredException extends UnauthorizedException {
+
+    public TokenExpiredException() {
+        super("로그인 인증 유효기간이 만료되었습니다. 다시 로그인 해주세요.", 1014);
+    }
+
+    public TokenExpiredException(String message) {
+        super(message, 1014);
+    }
+}

--- a/src/main/java/bangwool/server/exception/unauthorized/UnauthorizedException.java
+++ b/src/main/java/bangwool/server/exception/unauthorized/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package bangwool.server.exception.unauthorized;
+
+import bangwool.server.exception.BangwoolException;
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends BangwoolException {
+
+    public UnauthorizedException(String message, int code) {
+        super(HttpStatus.UNAUTHORIZED, message, code);
+    }
+}

--- a/src/main/java/bangwool/server/repository/MemberRepository.java
+++ b/src/main/java/bangwool/server/repository/MemberRepository.java
@@ -3,5 +3,8 @@ package bangwool.server.repository;
 import bangwool.server.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/bangwool/server/security/EncryptUtils.java
+++ b/src/main/java/bangwool/server/security/EncryptUtils.java
@@ -1,0 +1,25 @@
+package bangwool.server.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class EncryptUtils {
+
+    private static final String ENCRYPT_ALGORITHM = "SHA-256";
+    private static final String FORMAT_CODE = "%02x";
+
+    public static String encrypt(String value) {
+        try {
+            MessageDigest sha256 = MessageDigest.getInstance(ENCRYPT_ALGORITHM);
+            byte[] digest = sha256.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : digest) {
+                hexString.append(String.format(FORMAT_CODE, b));
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException("Apple OAuth 통신 암호화 과정 중 문제가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/bangwool/server/security/auth/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/bangwool/server/security/auth/AuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,33 @@
+package bangwool.server.security.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthenticationPrincipalArgumentResolver(final JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = AuthorizationExtractor.extractAccessToken(request);
+        String payload = jwtTokenProvider.getPayload(token);
+        return Long.parseLong(payload);
+    }
+}

--- a/src/main/java/bangwool/server/security/auth/AuthorizationExtractor.java
+++ b/src/main/java/bangwool/server/security/auth/AuthorizationExtractor.java
@@ -1,0 +1,35 @@
+package bangwool.server.security.auth;
+
+import bangwool.server.exception.badreqeust.BlankTokenException;
+import bangwool.server.exception.unauthorized.InvalidBearerException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.NoArgsConstructor;
+
+import java.util.Enumeration;
+
+@NoArgsConstructor
+public class AuthorizationExtractor {
+
+    private static final String AUTHENTICATION_TYPE = "Bearer";
+    private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
+    private static final int START_TOKEN_INDEX = 6;
+
+    public static String extractAccessToken(HttpServletRequest request) {
+        Enumeration<String> headers = request.getHeaders(AUTHORIZATION_HEADER_KEY);
+        while (headers.hasMoreElements()) {
+            String value = headers.nextElement();
+            if (value.toLowerCase().startsWith(AUTHENTICATION_TYPE.toLowerCase())) {
+                String extractToken = value.trim().substring(START_TOKEN_INDEX);
+                validateExtractToken(extractToken);
+                return extractToken;
+            }
+        }
+        throw new InvalidBearerException();
+    }
+
+    private static void validateExtractToken(String extractToken) {
+        if (extractToken.isBlank()) {
+            throw new BlankTokenException();
+        }
+    }
+}

--- a/src/main/java/bangwool/server/security/auth/JwtTokenProvider.java
+++ b/src/main/java/bangwool/server/security/auth/JwtTokenProvider.java
@@ -12,13 +12,11 @@ import java.util.Date;
 public class JwtTokenProvider {
     private final String secretKey;
     private final long validityInMilliseconds;
-    private final JwtParser jwtParser;
 
     public JwtTokenProvider(@Value("${security.jwt.token.secret-key}") String secretKey,
                             @Value("${security.jwt.token.expire-length}") long validityInMilliseconds) {
         this.secretKey = secretKey;
         this.validityInMilliseconds = validityInMilliseconds;
-        this.jwtParser = Jwts.parser().setSigningKey(secretKey);
     }
 
     public String createToken(Long memberId) {
@@ -35,7 +33,7 @@ public class JwtTokenProvider {
 
     public void validateToken(String token) {
         try {
-            jwtParser.parseClaimsJws(token);
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
         } catch (ExpiredJwtException e) {
             throw new TokenExpiredException();
         } catch (JwtException e) {
@@ -45,7 +43,7 @@ public class JwtTokenProvider {
 
     public String getPayload(String token) {
         try {
-            return jwtParser.parseClaimsJws(token).getBody().getSubject();
+            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
         } catch (ExpiredJwtException e) {
             throw new TokenExpiredException();
         } catch (JwtException e) {

--- a/src/main/java/bangwool/server/security/auth/JwtTokenProvider.java
+++ b/src/main/java/bangwool/server/security/auth/JwtTokenProvider.java
@@ -1,0 +1,55 @@
+package bangwool.server.security.auth;
+
+import bangwool.server.exception.unauthorized.InvalidTokenException;
+import bangwool.server.exception.unauthorized.TokenExpiredException;
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+    private final String secretKey;
+    private final long validityInMilliseconds;
+    private final JwtParser jwtParser;
+
+    public JwtTokenProvider(@Value("${security.jwt.token.secret-key}") String secretKey,
+                            @Value("${security.jwt.token.expire-length}") long validityInMilliseconds) {
+        this.secretKey = secretKey;
+        this.validityInMilliseconds = validityInMilliseconds;
+        this.jwtParser = Jwts.parser().setSigningKey(secretKey);
+    }
+
+    public String createToken(Long memberId) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(memberId))
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public void validateToken(String token) {
+        try {
+            jwtParser.parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException();
+        } catch (JwtException e) {
+            throw new InvalidTokenException();
+        }
+    }
+
+    public String getPayload(String token) {
+        try {
+            return jwtParser.parseClaimsJws(token).getBody().getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException();
+        } catch (JwtException e) {
+            throw new InvalidTokenException();
+        }
+    }
+}

--- a/src/main/java/bangwool/server/security/auth/LoginInterceptor.java
+++ b/src/main/java/bangwool/server/security/auth/LoginInterceptor.java
@@ -1,0 +1,36 @@
+package bangwool.server.security.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class LoginInterceptor implements HandlerInterceptor {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public LoginInterceptor(final JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (isPreflight(request) || isSwaggerRequest(request)) {
+            return true;
+        }
+
+        String token = AuthorizationExtractor.extractAccessToken(request);
+        jwtTokenProvider.validateToken(token);
+        return true;
+    }
+
+    private boolean isSwaggerRequest(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        return uri.contains("swagger") || uri.contains("api-docs") || uri.contains("webjars");
+    }
+
+    private boolean isPreflight(HttpServletRequest request) {
+        return request.getMethod().equals(HttpMethod.OPTIONS.toString());
+    }
+}

--- a/src/main/java/bangwool/server/security/auth/LoginUserId.java
+++ b/src/main/java/bangwool/server/security/auth/LoginUserId.java
@@ -1,0 +1,13 @@
+package bangwool.server.security.auth;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUserId {
+}
+

--- a/src/main/java/bangwool/server/service/AuthService.java
+++ b/src/main/java/bangwool/server/service/AuthService.java
@@ -10,9 +10,11 @@ import bangwool.server.security.auth.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthService {
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/bangwool/server/service/AuthService.java
+++ b/src/main/java/bangwool/server/service/AuthService.java
@@ -1,0 +1,42 @@
+package bangwool.server.service;
+
+import bangwool.server.domain.Member;
+import bangwool.server.dto.request.AuthLoginRequest;
+import bangwool.server.dto.response.TokenResponse;
+import bangwool.server.exception.badreqeust.PasswordMismatchException;
+import bangwool.server.exception.notfound.NotFoundMemberException;
+import bangwool.server.repository.MemberRepository;
+import bangwool.server.security.auth.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+
+    public TokenResponse login(AuthLoginRequest request) {
+        Member findMember = memberRepository.findByEmail(request.getEmail())
+                .orElseThrow(NotFoundMemberException::new);
+        validatePassword(findMember, request.getPassword());
+
+        String token = issueToken(findMember);
+
+        return TokenResponse.from(token);
+    }
+
+    private void validatePassword(final Member findMember, final String password) {
+        if (!passwordEncoder.matches(password, findMember.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+    }
+
+    private String issueToken(final Member findMember) {
+        return jwtTokenProvider.createToken(findMember.getId());
+    }
+
+}

--- a/src/main/java/bangwool/server/service/MemberService.java
+++ b/src/main/java/bangwool/server/service/MemberService.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +22,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional
     public MemberSignUpResponse save(MemberSignUpRequest memberSignUpRequest) {
         final String PARSER = "VALUES";
         String encodedPassword = passwordEncoder.encode(memberSignUpRequest.getPassword());

--- a/src/main/java/bangwool/server/service/MemberService.java
+++ b/src/main/java/bangwool/server/service/MemberService.java
@@ -7,28 +7,30 @@ import bangwool.server.dto.response.MemberSignUpResponse;
 import bangwool.server.exception.badreqeust.DuplicateEmailException;
 import bangwool.server.exception.badreqeust.DuplicateNickNameException;
 import bangwool.server.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 @Slf4j
 public class MemberService {
 
     private final MemberRepository memberRepository;
-
-    public MemberService(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
+    private final PasswordEncoder passwordEncoder;
 
     public MemberSignUpResponse save(MemberSignUpRequest memberSignUpRequest) {
         final String PARSER = "VALUES";
+        String encodedPassword = passwordEncoder.encode(memberSignUpRequest.getPassword());
+
 
         Member member = Member.builder()
                 .name(memberSignUpRequest.getName())
                 .email(memberSignUpRequest.getEmail())
                 .nickname(memberSignUpRequest.getNickname())
-                .password(memberSignUpRequest.getPassword())
+                .password(encodedPassword)
                 .build();
 
         try {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,13 @@ spring:
 security.jwt.token:
   secret-key: testtesttesttesttesttesttesttesttesttest
   expire-length: 864000
+
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+    tags-sorter: alpha


### PR DESCRIPTION
## 개요
- 로그인 기능 및 swagger로 api docs를 보기 편하게 만들었습니다.

## 작업사항
- 로그인 기능을 구현했습니다.
- 로그인 및 회원 가입 시 자동으로 비밀 번호가 암호화되게끔 만들었습니다.
- 이후 로그인시 Authentication 헤더에 token 값을 자동으로 읽어 @LogInId 어노테이션이 붙은 파라미터에 자동으로 값을 할당해줍니다.
- 각종 예외 사항을 체크했습니다.
- api docs를 고민하다가 swagger로 등록했습니다. swagger로 보는 방법은 추후 공유하겠습니다.

## 주의사항
- 별도의 테스트는 만들지 않았습니다.
- swagger 공유 후 swagger로 동작 확인 한번만 부탁드려요.

