### PR TITLE
Bw 74 back 마이페이지 api

### DIFF
--- a/src/main/java/bangwool/server/controller/AnnouncementController.java
+++ b/src/main/java/bangwool/server/controller/AnnouncementController.java
@@ -1,5 +1,7 @@
 package bangwool.server.controller;
 
+import bangwool.server.domain.Announcement;
+import bangwool.server.dto.response.AnnouncementResponse;
 import bangwool.server.dto.response.AnnouncementsResponse;
 import bangwool.server.security.auth.LoginUserId;
 import bangwool.server.service.AnnouncementService;
@@ -9,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,7 +27,15 @@ public class AnnouncementController {
     @GetMapping("/all")
     @Operation(summary = "공지사항 조회")
     public ResponseEntity<AnnouncementsResponse> getAnnouncements(@LoginUserId Long memberId) {
-        AnnouncementsResponse response = new AnnouncementsResponse(announcementService.getAnnouncements(memberId));
+        AnnouncementsResponse response = new AnnouncementsResponse(announcementService.getAnnouncements());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{announcementId}")
+    @Operation(summary = "특정 공지사항 조회")
+    public ResponseEntity<AnnouncementResponse> getAnnouncement(@LoginUserId Long memberId, @PathVariable Long announcementId) {
+        Announcement announcement = announcementService.getAnnouncement(announcementId);
+        AnnouncementResponse response = new AnnouncementResponse(announcement.getTitle(), announcement.getDescription(), announcement.getCreateDate(), announcement.getUpdateDate());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/bangwool/server/controller/AnnouncementController.java
+++ b/src/main/java/bangwool/server/controller/AnnouncementController.java
@@ -1,0 +1,31 @@
+package bangwool.server.controller;
+
+import bangwool.server.dto.response.AnnouncementsResponse;
+import bangwool.server.security.auth.LoginUserId;
+import bangwool.server.service.AnnouncementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Announcement", description = "공지사항")
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/announcement")
+public class AnnouncementController {
+
+    private final AnnouncementService announcementService;
+
+    @GetMapping("/all")
+    @Operation(summary = "공지사항 조회")
+    public ResponseEntity<AnnouncementsResponse> getAnnouncements(@LoginUserId Long memberId) {
+        AnnouncementsResponse response = new AnnouncementsResponse(announcementService.getAnnouncements(memberId));
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/bangwool/server/controller/MemberController.java
+++ b/src/main/java/bangwool/server/controller/MemberController.java
@@ -5,6 +5,7 @@ import bangwool.server.dto.response.*;
 import bangwool.server.security.auth.LoginUserId;
 import bangwool.server.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,12 +43,14 @@ public class MemberController {
     }
 
     @Operation(summary = "마이페이지 조회")
+    @SecurityRequirement(name = "JWT")
     @GetMapping("/mypage")
     public ResponseEntity<MypageResponse> getMypage(@LoginUserId Long memberId){
         MypageResponse mypageResponse = memberService.findMypage(memberId);
         return ResponseEntity.ok(mypageResponse);
     }
     @Operation(summary = "비밀번호 변경")
+    @SecurityRequirement(name = "JWT")
     @GetMapping("/chagepassword")
     public ResponseEntity<PasswordChangeResponse> changePassword(@LoginUserId Long memberId, String password){
         PasswordChangeResponse passwordChangeResponse = memberService.changePassword(memberId, password);
@@ -55,6 +58,7 @@ public class MemberController {
     }
 
     @Operation(summary = "회원 탈퇴")
+    @SecurityRequirement(name = "JWT")
     @GetMapping("/signout")
     public ResponseEntity<SignoutResponse> signOut(@LoginUserId Long memberId){
         SignoutResponse signoutResponse = memberService.signOut(memberId);

--- a/src/main/java/bangwool/server/controller/MemberController.java
+++ b/src/main/java/bangwool/server/controller/MemberController.java
@@ -4,6 +4,7 @@ import bangwool.server.dto.request.MemberSignUpRequest;
 import bangwool.server.dto.response.ExistResponse;
 import bangwool.server.dto.response.MemberSignUpResponse;
 import bangwool.server.dto.response.MypageResponse;
+import bangwool.server.dto.response.PasswordChangeResponse;
 import bangwool.server.security.auth.LoginUserId;
 import bangwool.server.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,4 +50,11 @@ public class MemberController {
         MypageResponse mypageResponse = memberService.findMypage(memberId);
         return ResponseEntity.ok(mypageResponse);
     }
+    @Operation(summary = "비밀번호 변경")
+    @GetMapping("/chagepassword")
+    public ResponseEntity<PasswordChangeResponse> changePassword(@LoginUserId Long memberId, String password){
+        PasswordChangeResponse passwordChangeResponse = memberService.changePassword(memberId, password);
+        return ResponseEntity.ok(passwordChangeResponse);
+    }
+
 }

--- a/src/main/java/bangwool/server/controller/MemberController.java
+++ b/src/main/java/bangwool/server/controller/MemberController.java
@@ -1,10 +1,7 @@
 package bangwool.server.controller;
 
 import bangwool.server.dto.request.MemberSignUpRequest;
-import bangwool.server.dto.response.ExistResponse;
-import bangwool.server.dto.response.MemberSignUpResponse;
-import bangwool.server.dto.response.MypageResponse;
-import bangwool.server.dto.response.PasswordChangeResponse;
+import bangwool.server.dto.response.*;
 import bangwool.server.security.auth.LoginUserId;
 import bangwool.server.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -55,6 +52,13 @@ public class MemberController {
     public ResponseEntity<PasswordChangeResponse> changePassword(@LoginUserId Long memberId, String password){
         PasswordChangeResponse passwordChangeResponse = memberService.changePassword(memberId, password);
         return ResponseEntity.ok(passwordChangeResponse);
+    }
+
+    @Operation(summary = "회원 탈퇴")
+    @GetMapping("/signout")
+    public ResponseEntity<SignoutResponse> signOut(@LoginUserId Long memberId){
+        SignoutResponse signoutResponse = memberService.signOut(memberId);
+        return ResponseEntity.ok(signoutResponse);
     }
 
 }

--- a/src/main/java/bangwool/server/domain/Announcement.java
+++ b/src/main/java/bangwool/server/domain/Announcement.java
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class Announcement {
 
     @Id

--- a/src/main/java/bangwool/server/domain/Announcement.java
+++ b/src/main/java/bangwool/server/domain/Announcement.java
@@ -1,0 +1,32 @@
+package bangwool.server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class Announcement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "ID", nullable = false)
+    private Long id;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "description")
+    private String description;
+
+    @CreatedDate
+    @Column(name = "create_date")
+    private String createDate;
+
+    @UpdateTimestamp
+    @Column(name = "update_date")
+    private String updateDate;
+
+}

--- a/src/main/java/bangwool/server/dto/response/AnnouncementResponse.java
+++ b/src/main/java/bangwool/server/dto/response/AnnouncementResponse.java
@@ -1,0 +1,17 @@
+package bangwool.server.dto.response;
+
+import lombok.AllArgsConstructor;
+
+public class AnnouncementResponse {
+    private String title;
+    private String description;
+    private String createDate;
+    private String updateDate;
+
+    public AnnouncementResponse(String title, String description, String createDate, String updateDate) {
+        this.title = title;
+        this.description = description;
+        this.createDate = createDate;
+        this.updateDate = updateDate;
+    }
+}

--- a/src/main/java/bangwool/server/dto/response/AnnouncementsResponse.java
+++ b/src/main/java/bangwool/server/dto/response/AnnouncementsResponse.java
@@ -1,0 +1,14 @@
+package bangwool.server.dto.response;
+
+import bangwool.server.domain.Announcement;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Setter
+public class AnnouncementsResponse {
+    private List<Announcement> announcementList;
+}

--- a/src/main/java/bangwool/server/dto/response/MypageResponse.java
+++ b/src/main/java/bangwool/server/dto/response/MypageResponse.java
@@ -9,6 +9,7 @@ import lombok.*;
 public class MypageResponse {
 
     private String email;
+    private String name;
     private String nickname;
     private String profileImage;
     //private Ranking ranking;

--- a/src/main/java/bangwool/server/dto/response/PasswordChangeResponse.java
+++ b/src/main/java/bangwool/server/dto/response/PasswordChangeResponse.java
@@ -1,0 +1,10 @@
+package bangwool.server.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@AllArgsConstructor
+public class PasswordChangeResponse {
+    private Boolean isChanged;
+}

--- a/src/main/java/bangwool/server/dto/response/SignoutResponse.java
+++ b/src/main/java/bangwool/server/dto/response/SignoutResponse.java
@@ -1,0 +1,10 @@
+package bangwool.server.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@AllArgsConstructor
+public class SignoutResponse {
+    private Long id;
+}

--- a/src/main/java/bangwool/server/dto/response/SignoutResponse.java
+++ b/src/main/java/bangwool/server/dto/response/SignoutResponse.java
@@ -6,5 +6,5 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class SignoutResponse {
-    private Long id;
+    private Boolean isSuccess;
 }

--- a/src/main/java/bangwool/server/repository/AnnouncementRepository.java
+++ b/src/main/java/bangwool/server/repository/AnnouncementRepository.java
@@ -1,0 +1,14 @@
+package bangwool.server.repository;
+
+import bangwool.server.domain.Announcement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+
+    @Override
+    List<Announcement> findAll();
+
+}

--- a/src/main/java/bangwool/server/repository/AnnouncementRepository.java
+++ b/src/main/java/bangwool/server/repository/AnnouncementRepository.java
@@ -4,11 +4,9 @@ import bangwool.server.domain.Announcement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
-
-    @Override
-    List<Announcement> findAll();
 
 }

--- a/src/main/java/bangwool/server/repository/MemberRepository.java
+++ b/src/main/java/bangwool/server/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package bangwool.server.repository;
 import bangwool.server.domain.Member;
 import bangwool.server.domain.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
@@ -17,4 +18,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findById(Long id);
     Optional<Member> findByNickname(String nickname);
 
+    @Modifying
+    @Query("update Member m set m.password = :encodedPassword where m.id = :id")
+    void updatePasswordById(Long id, String encodedPassword);
 }

--- a/src/main/java/bangwool/server/service/AnnouncementService.java
+++ b/src/main/java/bangwool/server/service/AnnouncementService.java
@@ -17,8 +17,12 @@ public class AnnouncementService {
 
     private final AnnouncementRepository announcementRepository;
 
-    public List<Announcement> getAnnouncements(Long id){
+    public List<Announcement> getAnnouncements(){
         return announcementRepository.findAll();
+    }
+
+    public Announcement getAnnouncement(Long id){
+        return announcementRepository.findById(id).get();
     }
 
 

--- a/src/main/java/bangwool/server/service/AnnouncementService.java
+++ b/src/main/java/bangwool/server/service/AnnouncementService.java
@@ -1,0 +1,25 @@
+package bangwool.server.service;
+
+import bangwool.server.domain.Announcement;
+import bangwool.server.dto.response.AnnouncementsResponse;
+import bangwool.server.repository.AnnouncementRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AnnouncementService {
+
+    private final AnnouncementRepository announcementRepository;
+
+    public List<Announcement> getAnnouncements(Long id){
+        return announcementRepository.findAll();
+    }
+
+
+}

--- a/src/main/java/bangwool/server/service/MemberService.java
+++ b/src/main/java/bangwool/server/service/MemberService.java
@@ -6,6 +6,7 @@ import bangwool.server.domain.Ranking;
 import bangwool.server.dto.request.MemberSignUpRequest;
 import bangwool.server.dto.response.ExistResponse;
 import bangwool.server.dto.response.MemberSignUpResponse;
+import bangwool.server.dto.response.PasswordChangeResponse;
 import bangwool.server.exception.badreqeust.DuplicateException;
 import bangwool.server.dto.response.MypageResponse;
 import bangwool.server.exception.notfound.NotFoundMemberException;
@@ -16,8 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -76,6 +75,12 @@ public class MemberService {
         Member member = memberRepository.findById(id)
                 .orElseThrow(NotFoundMemberException::new);
         return new MypageResponse(member.getEmail(), member.getName() ,member.getNickname(), member.getProfile());
+    }
+
+    public PasswordChangeResponse changePassword(Long id, String password){
+        String encodedPassword = passwordEncoder.encode(password);
+        memberRepository.updatePasswordById(id, encodedPassword);
+        return new PasswordChangeResponse(true);
     }
 
 }

--- a/src/main/java/bangwool/server/service/MemberService.java
+++ b/src/main/java/bangwool/server/service/MemberService.java
@@ -75,7 +75,7 @@ public class MemberService {
     public MypageResponse findMypage(Long id) {
         Member member = memberRepository.findById(id)
                 .orElseThrow(NotFoundMemberException::new);
-        return new MypageResponse(member.getEmail(), member.getNickname(), member.getProfile());
+        return new MypageResponse(member.getEmail(), member.getName() ,member.getNickname(), member.getProfile());
     }
 
 }

--- a/src/main/java/bangwool/server/service/MemberService.java
+++ b/src/main/java/bangwool/server/service/MemberService.java
@@ -4,11 +4,8 @@ package bangwool.server.service;
 import bangwool.server.domain.Member;
 import bangwool.server.domain.Ranking;
 import bangwool.server.dto.request.MemberSignUpRequest;
-import bangwool.server.dto.response.ExistResponse;
-import bangwool.server.dto.response.MemberSignUpResponse;
-import bangwool.server.dto.response.PasswordChangeResponse;
+import bangwool.server.dto.response.*;
 import bangwool.server.exception.badreqeust.DuplicateException;
-import bangwool.server.dto.response.MypageResponse;
 import bangwool.server.exception.notfound.NotFoundMemberException;
 import bangwool.server.repository.MemberRepository;
 import bangwool.server.repository.RankingRepository;
@@ -77,10 +74,18 @@ public class MemberService {
         return new MypageResponse(member.getEmail(), member.getName() ,member.getNickname(), member.getProfile());
     }
 
-    public PasswordChangeResponse changePassword(Long id, String password){
+    public PasswordChangeResponse changePassword(Long id, String password) {
         String encodedPassword = passwordEncoder.encode(password);
         memberRepository.updatePasswordById(id, encodedPassword);
         return new PasswordChangeResponse(true);
     }
+
+    public SignoutResponse signOut(Long id) {
+        memberRepository.deleteById(id);
+        return new SignoutResponse(id);
+    }
+
+
+
 
 }

--- a/src/main/java/bangwool/server/service/MemberService.java
+++ b/src/main/java/bangwool/server/service/MemberService.java
@@ -82,10 +82,8 @@ public class MemberService {
 
     public SignoutResponse signOut(Long id) {
         memberRepository.deleteById(id);
-        return new SignoutResponse(id);
+        return new SignoutResponse(true);
     }
-
-
 
 
 }


### PR DESCRIPTION
## 개요
mypage에서 사용하는 API 기능들 추가

## 작업사항
- DB 접근 기능 구현 시 sql 쿼리문이 나가는 횟수를 함께 적어주세요.
mypage에서 회원정보 불러올 때 name도 불러오게 수정
비밀번호 변경 API 추가
회원탈퇴 API 추가
공지사항 전체 조회 API 추가
특정 공지사항 조회 API 추가

## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가

